### PR TITLE
Refactor movies service and types

### DIFF
--- a/services/movies.ts
+++ b/services/movies.ts
@@ -114,7 +114,6 @@ export const _getHotCinemaMovies = async (): Promise<Movie[]> => {
       result.push({
         name: name,
         showings,
-        img: "",
       });
     }
   }
@@ -144,7 +143,9 @@ const loadMovies = async (): Promise<void> => {
       cinemaCityMovies.push(movie);
     }
   }
-  cache.movies = cinemaCityMovies;
+  cache.movies = cinemaCityMovies.filter((movie) =>
+    movie.img && movie.name.length > 1
+  );
 };
 
 // refresh movies 10 hours

--- a/types.ts
+++ b/types.ts
@@ -16,7 +16,7 @@ export type Showing = {
 export type Movie = {
   name: string;
   showings: Showing[];
-  img: string;
+  img?: string;
 };
 
 // cinema city


### PR DESCRIPTION
- Remove unnecessary "img" property in _getHotCinemaMovies function.
- Update loadMovies function to filter out movies without "img" and with name length less than 2.
- Update "img" property in Movie interface in types.ts to be optional.